### PR TITLE
Removal of deprecated dashboard_num_columns

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -30,7 +30,7 @@
     <integer name="maximum_user_dictionary_word_length" translatable="false">48</integer>
 
     <!-- Dashboard number of columns -->
-    <integer name="dashboard_num_columns">1</integer>
+    <!--<integer name="dashboard_num_columns">1</integer>-->
 
     <!-- Whether to hide IMS and DUN Apns -->
     <bool name="config_regional_hide_ims_and_dun_apns">false</bool>


### PR DESCRIPTION
The dashboard column divisions have been deprecated in the nougat. Attempt to re-enable could be done.
But removal is necessary to make sure one doesn't confuse.